### PR TITLE
Fix minimize and 4k/scaling behavior

### DIFF
--- a/hook.cpp
+++ b/hook.cpp
@@ -30,7 +30,12 @@ bool apply_hooks() {
 	// allow alt tab - set dwExStyle from WS_EX_TOPMOST to WS_EX_LEFT (default), which allows minimizing
 	XUNLOCK((void*)0x5083b1, 1);
 	memset((void*)0x5083b1, 0x00, 1);
-	
+
+	// fix bad bahavior on 4k monitors - avoid redundant ChangeDisplaySettingsA
+	XUNLOCK((void*)0x508821, 2);
+	memset((void*)0x508821, 0x90, 1);
+	memset((void*)0x508822, 0x90, 1);
+
 	HMODULE hModule;
 	if (SUCCEEDED(GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)apply_hooks, &hModule)))
 	{

--- a/hook.cpp
+++ b/hook.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "shared.h"
 #include "client.h"
+#include "stdafx.h"
 
 //0046319B E8 10 B1 FA FF                                      call    sub_40E2B0
 void sub_40E2B0() {
@@ -25,6 +26,11 @@ void Main_UnprotectModule(HMODULE hModule)
 }
 
 bool apply_hooks() {
+
+	// allow alt tab - set dwExStyle from WS_EX_TOPMOST to WS_EX_LEFT (default), which allows minimizing
+	XUNLOCK((void*)0x5083b1, 1);
+	memset((void*)0x5083b1, 0x00, 1);
+	
 	HMODULE hModule;
 	if (SUCCEEDED(GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)apply_hooks, &hModule)))
 	{


### PR DESCRIPTION
- Changes window `dwExStyle` - to be able to minimize window using alt-tab or winkey
- Fix for 4k monitor along with 200% zoom setting in windows. Without the fix, a window is not properly scaled, and user cannot see full window contents, see example screenshot: 
![obraz](https://user-images.githubusercontent.com/4583553/131262814-e075ffb6-9214-4849-8e3e-3fb9fae32a7d.png)
